### PR TITLE
Added primary keys for votes tables

### DIFF
--- a/src/db.sql
+++ b/src/db.sql
@@ -1,8 +1,19 @@
+DROP TABLE IF EXISTS comment_votes;
+DROP TABLE IF EXISTS rating_votes;
+DROP TABLE IF EXISTS comments;
 DROP TABLE IF EXISTS rating;
 DROP TABLE IF EXISTS users;
-DROP TABLE IF EXISTS comments;
-DROP TABLE IF EXISTS rating_votes;
-DROP TABLE IF EXISTS comment_votes;
+
+CREATE TABLE IF NOT EXISTS users(
+    user_id SERIAL PRIMARY KEY,
+    username VARCHAR(255),
+    password VARCHAR(255),
+    first_name VARCHAR(255),
+    last_name VARCHAR(255),
+    email VARCHAR(255),
+    favorite VARCHAR(255),
+    picture VARCHAR(255)
+);
 
 CREATE TABLE IF NOT EXISTS rating(
     rating_id SERIAL PRIMARY KEY,
@@ -15,18 +26,7 @@ CREATE TABLE IF NOT EXISTS rating(
     map_tag VARCHAR(255),
     votes INTEGER,
     rater_id INTEGER,
-    FOREIGN KEY (rater_id) REFERENCES users(user_id) ON DELETE CASCADE;
-);
-
-CREATE TABLE IF NOT EXISTS users(
-    user_id SERIAL PRIMARY KEY,
-    username VARCHAR(255),
-    password VARCHAR(255),
-    first_name VARCHAR(255),
-    last_name VARCHAR(255),
-    email VARCHAR(255),
-    favorite VARCHAR(255),
-    picture VARCHAR(255)
+    FOREIGN KEY (rater_id) REFERENCES users(user_id) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS comments(
@@ -40,18 +40,18 @@ CREATE TABLE IF NOT EXISTS comments(
 );
 
 CREATE TABLE IF NOT EXISTS rating_votes(
+    rating_id INT PRIMARY KEY,
     upvotes INT,
     downvotes INT,
-    rating_id INT,
     user_id INT,
     FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE,
     FOREIGN KEY (rating_id) REFERENCES rating(rating_id) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS comment_votes(
+    comment_id INT PRIMARY KEY,
     upvotes INT,
     downvotes INT,
-    comment_id INT,
     user_id INT,
     FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE,
     FOREIGN KEY (comment_id) REFERENCES comments(comment_id) ON DELETE CASCADE


### PR DESCRIPTION
Primary keys for votes table are currently the rating/comment they respectively belong to. Also changed the order of drop table statements so the code can run correctly